### PR TITLE
Fix typo in collection sharing

### DIFF
--- a/docs/guides/collection_sharing.mdx
+++ b/docs/guides/collection_sharing.mdx
@@ -7,7 +7,7 @@ import TabItem from '@theme/TabItem';
 
 
 :::note
-In the future we will have more ways to share collections among users (e.g: [PAKE](https://en.wikipedia.org/wiki/Password-authenticated_key_agreement)), but until we do, the only way to sure is using [public-key cryptography](https://en.wikipedia.org/wiki/Public-key_cryptography) which is what this section is about.
+In the future we will have more ways to share collections among users (e.g: [PAKE](https://en.wikipedia.org/wiki/Password-authenticated_key_agreement)), but until we do, the only way to share is using [public-key cryptography](https://en.wikipedia.org/wiki/Public-key_cryptography) which is what this section is about.
 :::
 
 This section assumes you have already read the [collections](./using_collections) section and are familiar with collections.


### PR DESCRIPTION
I found this while reading the docs, it's a small typo fix.