### PR TITLE
Use same variable name for JavaScript

### DIFF
--- a/docs/guides/using_items.mdx
+++ b/docs/guides/using_items.mdx
@@ -1869,7 +1869,7 @@ Some applications are interactive in nature and their data changes often. For th
 <TabItem value="js">
 
 ```js
-const subscription = await itemMgr.subscribeChanges((items) => {
+const subscription = await itemManager.subscribeChanges((items) => {
     /*
     items:
     {


### PR DESCRIPTION
Related to [Benjamin_Loison/etebase-docs/issues/4](https://codeberg.org/Benjamin_Loison/etebase-docs/issues/4).